### PR TITLE
Alpha: Add LiveStats_CanPerformStatOperation hook

### DIFF
--- a/Source/Builds/Alpha/CoDMP/Main.cpp
+++ b/Source/Builds/Alpha/CoDMP/Main.cpp
@@ -143,6 +143,12 @@ namespace Online
 		return;
 	}
 
+	Utils::Hook::Detour LiveStats_CanPerformStatOperation_Hook;
+	int LiveStats_CanPerformStatOperation(int Controllerindex_t)
+	{
+		return 1;
+	}
+
 	void RegisterHooks()
 	{
 		Live_IsUserSignedInToDemonware_Hook.Create(0x82763C10, Live_IsUserSignedInToDemonware);
@@ -159,6 +165,7 @@ namespace Online
 		LiveElite_CheckProgress_Hook.Create(0x8276FD78, LiveElite_CheckProgress);
 		LiveCAC_CheckProgress_Hook.Create(0x824E1888, LiveCAC_CheckProgress);
 		SanityCheckSession_Hook.Create(0x82787E90, SanityCheckSession);
+		LiveStats_CanPerformStatOperation_Hook.Create(0x8278EDB8 , LiveStats_CanPerformStatOperation);
 
 		Utils::Hook::SetValue<uint8_t>(0x849016D4, 1); // s_geoLocationRetrieved
 	}
@@ -179,6 +186,7 @@ namespace Online
 		LiveElite_CheckProgress_Hook.Clear();
 		LiveCAC_CheckProgress_Hook.Clear();
 		SanityCheckSession_Hook.Clear();
+		LiveStats_CanPerformStatOperation_Hook.Clear();
 	}
 }
 

--- a/Source/Builds/Alpha/default_mp/Main.cpp
+++ b/Source/Builds/Alpha/default_mp/Main.cpp
@@ -143,6 +143,12 @@ namespace Online
 		return;
 	}
 
+	Utils::Hook::Detour LiveStats_CanPerformStatOperation_Hook;
+	int LiveStats_CanPerformStatOperation(int Controllerindex_t)
+	{
+		return 1;
+	}
+
 	void RegisterHooks()
 	{
 		Live_IsUserSignedInToDemonware_Hook.Create(0x824DD420, Live_IsUserSignedInToDemonware);
@@ -156,6 +162,7 @@ namespace Online
 		Utils::Hook::SetValue<uint8_t>(0x8425374C, 1); // s_geoLocationRetrieved
 		LiveElite_CheckProgress_Hook.Create(0x824E5998, LiveElite_CheckProgress);
 		LiveCAC_CheckProgress_Hook.Create(0x82347CC0, LiveCAC_CheckProgress);
+		LiveStats_CanPerformStatOperation_Hook.Create(0x824FBA08 , LiveStats_CanPerformStatOperation);
 	}
 
 	void UnregisterHooks()
@@ -170,6 +177,7 @@ namespace Online
 		LiveStorage_DoWeHaveContracts_Hook.Clear();
 		LiveElite_CheckProgress_Hook.Clear();
 		LiveCAC_CheckProgress_Hook.Clear();
+		LiveStats_CanPerformStatOperation_Hook.Clear();
 	}
 }
 

--- a/Source/Builds/Emulation/CoDMP/Main.cpp
+++ b/Source/Builds/Emulation/CoDMP/Main.cpp
@@ -185,7 +185,7 @@ namespace Online
 	}
 
 	Utils::Hook::Detour LiveStats_CanPerformStatOperation_Hook;
-	int LiveStats_CanPerformStatOperation(int a1)
+	int LiveStats_CanPerformStatOperation(int Controllerindex_t)
 	{
 		return 1;
 	}


### PR DESCRIPTION
forces LiveStats_CanPerformStatOperation to return 1 unconditionally. suppresses the "Downloading Game Settings" dialog. not a full fix just skips the gating logic.